### PR TITLE
Add decode to Windows service bytes output.

### DIFF
--- a/health_monitoring_plugins/windowsservice.py
+++ b/health_monitoring_plugins/windowsservice.py
@@ -56,7 +56,7 @@ class Windowsservice(object):
         print("Running services at host: " + helper.options.hostname)
 
         for service in all_services:
-            print("Service: \t'" + service + "'")
+            print("Service: \t'" + service.decode("utf-8") + "'")
 
         # we don't want to return a icinga output, so we just end the script here
         quit()


### PR DESCRIPTION
I was running into an error with listing all services.
    print("Service: \t'" + service + "'")
TypeError: can only concatenate str (not "bytes") to str

Added a decode to UTF-8, which is my best guess now a days.